### PR TITLE
Implement Message Authentication Code verification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ Methods
     #setKeyLength(newValue)
 
 
-TODO
---------------
-* Signature verification is missing.
-
 License
 --------------
 [MIT](https://github.com/smirzaei/rails-session-decoder/blob/master/LICENSE)

--- a/index.test.js
+++ b/index.test.js
@@ -82,7 +82,23 @@ describe('#decodeSignedCookie', function() {
     })
   });
 
-  //TODO: add a test case for signed cookie final value.
+  it('returns the expected values', function (done) {
+    decoder.decodeSignedCookie(cookie, function(err, result) {
+      (err == null).should.be.true;
+
+      JSON.parse(result).should.eql(session);
+
+      done();
+    })
+  });
+
+  it('returns error when the cookie signature is wrong', function (done) {
+    decoder.decodeSignedCookie(cookie.replace(/.$/,"f"), function(err, result) {
+      err.should.be.ok;
+
+      done();
+    })
+  });
 });
 
 describe('#setSecret', function() {


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-rails-session-decoder

### ⚙️ Description *

Implement verification of the Message Authentication Code appended to the cookies.

### 💻 Technical Description *

Cookie contains already calculated MAC (Message Authentication Code) in hex after a `--` separator. Verification happens, when one re-calculates MAC and compares it. It is calculated using HMAC SHA-1, where key is calculated the same way as cookie decryption key (PBKDF2, 1000 iterations, key length of 64), except that the salt is `signed encrypted cookie`.

### 👍 User Acceptance Testing (UAT)

Added test `#decodeSignedCookie returns error when the cookie signature is wrong` to verify implementation.

```
  ․ Constructor stores the secret: 1ms
  ․ Defaults has the correct digest: 0ms
  ․ Defaults has the correct cookieSalt: 0ms
  ․ Defaults has the correct signedCookieSalt: 0ms
  ․ Defaults has the correct iterations: 1ms
  ․ Defaults has the correct keyLength: 0ms
  ․ #decodeCookie returns error when the cookie is not provided: 2ms
  ․ #decodeCookie returns error when the format invalid: 0ms
  ․ #decodeCookie returns the expected values: 8ms
  ․ #decodeSignedCookie returns error when the cookie is not provided: 0ms
  ․ #decodeSignedCookie returns error when the format invalid: 1ms
  ․ #decodeSignedCookie returns the expected values: 8ms
  ․ #decodeSignedCookie returns error when the cookie signature is wrong: 2ms
  ․ #setSecret updates the secret: 0ms
  ․ #setDigest updates the digest: 1ms
  ․ #setCookieSalt updates the cookieSalt: 0ms
  ․ #setSignedCookieSalt updates the signedCookieSalt: 0ms
  ․ #setIterations updates the iterations: 0ms
  ․ #setKeyLength updates the keyLength: 0ms

  19 passing (43ms)
```